### PR TITLE
Whitelisting "END" and "WITH" sql_keywords.json

### DIFF
--- a/breathecode/sql_keywords.json
+++ b/breathecode/sql_keywords.json
@@ -44,6 +44,7 @@
         "CASE",
         "WHEN",
         "THEN",
+        "END",
         "IFNULL",
         "ISNULL",
         "COALESCE",
@@ -170,7 +171,8 @@
         "CONVERT",
         "IF",
         "LAST_INSERT_ID",
-        "NULLIF"
+        "NULLIF",
+        "WITH"
     ],
     "blacklist": [
         "FILTER",


### PR DESCRIPTION
Whitelisting "END", that was missing to complete the CASE sentences, and "WITH", for breaking down complex sentences.