### PR TITLE
Feature: add live_workshop_status endpoint with cache invalidation

### DIFF
--- a/breathecode/events/receivers.py
+++ b/breathecode/events/receivers.py
@@ -1,15 +1,16 @@
 import logging
 from typing import Any, Type
 
+from django.core.cache import cache
+from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils import timezone
 
 from breathecode.admissions.models import CohortTimeSlot
 from breathecode.admissions.signals import timeslot_saved
 from breathecode.events import tasks
-from breathecode.events.models import Event, FINISHED
-from breathecode.events.signals import event_status_updated
-
+from breathecode.events.models import FINISHED, Event
+from breathecode.events.signals import event_saved, event_status_updated
 
 logger = logging.getLogger(__name__)
 
@@ -37,3 +38,13 @@ def generate_event_recap_on_finished(sender: Type[Event], instance: Event, **kwa
     if instance.status == FINISHED:
         logger.info(f"Event {instance.id} marked as FINISHED, queuing recap generation")
         tasks.generate_event_recap.delay(instance.id)
+
+
+@receiver(event_saved)
+def invalidate_cache_on_event_saved(sender, instance, **kwargs):
+    cache.delete("live_workshop_status")
+
+
+@receiver(post_delete, sender=Event)
+def invalidate_cache_on_event_deleted(sender, instance, **kwargs):
+    cache.delete("live_workshop_status")

--- a/breathecode/events/urls.py
+++ b/breathecode/events/urls.py
@@ -29,6 +29,7 @@ from .views import (
     get_events,
     join_event,
     join_live_class,
+    live_workshop_status,
 )
 
 app_name = "events"
@@ -91,4 +92,5 @@ urlpatterns = [
     ),
     path("academy/checkin", AcademyEventCheckinView.as_view(), name="academy_checkin"),
     path("eventbrite/webhook/<int:organization_id>", eventbrite_webhook, name="eventbrite_webhook_id"),
+    path("live-workshop-status", live_workshop_status, name="live_workshop_status"),
 ]


### PR DESCRIPTION
### What's new?

* New API endpoint `/v1/events/live-workshop-status` to get the current live event or info about the next upcoming event.
* The endpoint caches its response with a timeout that adapts to the event schedule, reducing unnecessary DB queries.
* Cache is automatically invalidated when an event is created, updated, or deleted, ensuring up-to-date responses.
* Endpoint registered in urls.py.

**Files changed:**

* views.py: Implements the endpoint and caching logic.
* receivers.py: Adds signal receivers to invalidate the cache on event changes.
* urls.py: Registers the new endpoint.

---
**Issue:**
https://github.com/breatheco-de/breatheco-de/issues/9428