### PR TITLE
Added language to live event json response

### DIFF
--- a/breathecode/events/views.py
+++ b/breathecode/events/views.py
@@ -1762,6 +1762,7 @@ def live_workshop_status(request):
                 "slug": live_event.slug,
                 "starting_at": live_event.starting_at,
                 "ending_at": live_event.ending_at,
+                "lang": live_event.lang,
             }
             timeout = max(30, int((live_event.ending_at - now_dt).total_seconds()))
         else:


### PR DESCRIPTION
This PR adds the `lang` attribute to the response of the `live_workshop_status` endpoint. Now, when a live event is found, the API response will include the event's language under the `lang` key. This allows clients to easily identify the language of the current live event.

**Issue:**
https://github.com/breatheco-de/breatheco-de/issues/9534