### PR TITLE
Adjust special offers obtaining

### DIFF
--- a/breathecode/payments/actions.py
+++ b/breathecode/payments/actions.py
@@ -1147,15 +1147,18 @@ def get_available_coupons(
     cou_fields = ("id", "slug", "how_many_offers", "offered_at", "expires_at", "seller", "allowed_user")
 
     if not only_sent_coupons:
-        special_offers = (
+        special_offer = (
             Coupon.objects.filter(*cou_args, auto=True)
-            .exclude(Q(how_many_offers=0) | Q(discount_type=Coupon.Discount.NO_DISCOUNT))
+            .exclude(
+                Q(how_many_offers=0) | Q(discount_type=Coupon.Discount.NO_DISCOUNT) | Q(allowed_user__isnull=False)
+            )
             .select_related("seller__user", "allowed_user")
             .only(*cou_fields)
+            .first()
         )
+        print("special_offers", special_offer)
 
-        for coupon in special_offers:
-            manage_coupon(coupon)
+        manage_coupon(special_offer)
 
     valid_coupons = (
         Coupon.objects.filter(*cou_args, slug__in=coupons, auto=False)


### PR DESCRIPTION
Issue: https://github.com/breatheco-de/breatheco-de/issues/9953

La parte de special offers en el action de get_available_coupons, anteriormente se traia todos los cupones con auto = true, pero ahora que los reward coupons comenzaron a tener auto = true, esto tambien se traia esos cupones. Agregue un filtro para que no se traiga cupones con el campo aloowed_users definido (rewards)
Tambien, antes estos special offers traian todos los cupones que se encontraran, lo que ocasionaba que se pudiera ofertar mas de un cupon publico de oferta si habian varios con auto true (por ejemplo new-year-50 y LEARN-TECH), asi que hice que agarrara el primero solamente, que sera siempre el mas viejo con auto = true

Tambien modifique la vista de BagCouponView, que es la que se llama para agregar cupones a la bolsa, e hice que solamente agregara aquellos cupones enviados desde el checkout, ya que la busqueda de un cupon autoaplicado ya se hizo anteriormente al entrar al checkout