### PR TITLE
Include zero-balance consumables in academy service consumable endpoint

### DIFF
--- a/breathecode/payments/tests/urls/tests_academy_service_consumable.py
+++ b/breathecode/payments/tests/urls/tests_academy_service_consumable.py
@@ -130,6 +130,40 @@ class AcademyServiceConsumableTestCase(PaymentsTestCase):
         self.assertEqual(item["subscription"], model.subscription.id)
         self.assertEqual(item["how_many"], 10)
 
+    def test_includes_consumables_with_zero_balance(self):
+        """Zero-balance consumables still count while valid_until has not passed."""
+        subscription = {
+            "valid_until": UTC_NOW + timezone.timedelta(days=30),
+        }
+        consumable = {
+            "how_many": 0,
+            "unit_type": "UNIT",
+            "valid_until": UTC_NOW + timezone.timedelta(days=30),
+        }
+        service = {"type": "VOID"}
+        model = self.bc.database.create(
+            user=1,
+            role=1,
+            capability="read_consumable",
+            profile_academy=1,
+            subscription=subscription,
+            consumable=consumable,
+            service=service,
+            service_item=1,
+        )
+        self.bc.request.authenticate(model.user)
+
+        response = self.client.get(self.url)
+        json = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json["voids"]), 1)
+        void_item = json["voids"][0]
+        self.assertEqual(void_item["balance"]["unit"], 0)
+        self.assertEqual(len(void_item["items"]), 1)
+        self.assertEqual(void_item["items"][0]["how_many"], 0)
+        self.assertEqual(void_item["items"][0]["subscription"], model.subscription.id)
+
     def test_with_consumables_from_plan_financing(self):
         """Test retrieving consumables from a plan financing."""
         plan_financing = {

--- a/breathecode/payments/views.py
+++ b/breathecode/payments/views.py
@@ -2026,13 +2026,13 @@ class AcademyConsumableView(APIView):
         lang = get_user_language(request)
         utc_now = timezone.now()
 
-        # Start with consumables that belong to the academy through subscriptions, plan_financings, or staff grant
+        # Include how_many=0: user still holds the consumable during its valid period
         items = Consumable.objects.filter(
             Q(valid_until__gte=utc_now) | Q(valid_until=None),
             Q(subscription__academy_id=academy_id)
             | Q(plan_financing__academy_id=academy_id)
             | Q(standalone_invoice__bag__academy_id=academy_id),
-        ).exclude(how_many=0)
+        )
 
         # Filter by users if provided (comma-separated list of user IDs)
         if users := request.GET.get("users"):

--- a/docs/agent-docs/BC_SERVICE_STOCK_STATUS.md
+++ b/docs/agent-docs/BC_SERVICE_STOCK_STATUS.md
@@ -177,5 +177,5 @@ to copy the resource and then (if the scheduler is due) renewal can create the c
 ## Related
 
 - **Consumable balance (student view):** `GET /v1/payments/me/service/consumable`  
-- **Academy consumables (staff):** `GET /v1/payments/academy/service/consumable?users=<user_id>` (includes staff-granted and subscription/plan consumables for that academy).  
+- **Academy consumables (staff):** `GET /v1/payments/academy/service/consumable?users=<user_id>` (includes staff-granted and subscription/plan consumables for that academy, including `how_many=0` while still within `valid_until`).  
 - **CLI:** `python manage.py diagnose_scheduler --scheduler-id <id>` with optional `--fix-resource` and `--force-renew`.


### PR DESCRIPTION
## Summary
- El endpoint `GET /v1/payments/academy/service/consumable` excluía consumibles con `how_many=0`, lo que confundía a admins (parecía que no se había generado el consumible).
- Ahora se incluyen mientras sigan vigentes (`valid_until`), aunque el saldo sea 0.
- Test + doc actualizados.

Closes breatheco-de/breatheco-de#10888

## Test plan
- [ ] `GET /v1/payments/academy/service/consumable?users=<id>` con un usuario que tenga consumible vigente y `how_many=0` → aparece en la respuesta con balance 0
- [ ] Consumibles expirados siguen sin aparecer
- [ ] Consumibles con saldo > 0 / `-1` siguen comportándose igual
- [ ] Correr `tests_academy_service_consumable.py`